### PR TITLE
create a DistanceSensor wrapper around SR04

### DIFF
--- a/uno/Consts.h
+++ b/uno/Consts.h
@@ -1,20 +1,24 @@
 #ifndef CONSTANTS_H
 #define CONSTANTS_H
 
-#define NEAR_CTL_PIN 2
-#define FAR_CTL_PIN 3
-#define ECHO_PIN 4
-#define TRIGGER_PIN 5
+// Relay Pins
+const int NEAR_CTL_PIN =  2;
+const int FAR_CTL_PIN =  3;
 
-#define SERIAL_MSG_NEAR 0
-#define SERIAL_MSG_FAR 1
+// Sensor Pins
+const int ECHO_PIN =  4;
+const int TRIGGER_PIN =  5;
 
-#define PING_DELAY_MS 10
-#define PING_COUNT 30
 
-#define NEAR_MIN_CM 10
-#define NEAR_MAX_CM 30
-#define FAR_MIN_CM 40
-#define FAR_MAX_CM 100
+const int SERIAL_MSG_NEAR =  0;
+const int SERIAL_MSG_FAR =  1;
+
+const int PING_DELAY_MS =  10;
+const int PING_COUNT =  30;
+
+const int NEAR_MIN_CM =  10;
+const int NEAR_MAX_CM =  30;
+const int FAR_MIN_CM =  40;
+const int FAR_MAX_CM =  100;
 
 #endif

--- a/uno/Consts.h
+++ b/uno/Consts.h
@@ -5,10 +5,8 @@
 const int NEAR_CTL_PIN =  2;
 const int FAR_CTL_PIN =  3;
 
-// Sensor Pins
-const int ECHO_PIN =  4;
-const int TRIGGER_PIN =  5;
-
+const int SENSOR_PIN_IN =  5;
+const int SENSOR_PIN_OUT =  4;
 
 const int SERIAL_MSG_NEAR =  0;
 const int SERIAL_MSG_FAR =  1;

--- a/uno/DistanceMonitor.cpp
+++ b/uno/DistanceMonitor.cpp
@@ -1,15 +1,14 @@
 #include "DistanceMonitor.h"
 
 DistanceMonitor::DistanceMonitor(DistanceMonitorParams params) :
-  _sensor(params.sensor),
+  _sensor(params.sensorSettings.inPin, params.sensorSettings.outPin),
   _intervalSettings(params.intervalSettings),
   _nearRange(params.nearSettings.range),
   _farRange(params.farSettings.range),
   _nearHandler(params.nearSettings.withinRangeHandler),
-  _farHandler(params.farSettings.withinRangeHandler)
-{
-  _distance = params.farSettings.range.min;
-}
+  _farHandler(params.farSettings.withinRangeHandler),
+  _distance(params.farSettings.range.min)
+{}
 
 void DistanceMonitor::handleDistance() {
   _getDistance();
@@ -21,7 +20,7 @@ void DistanceMonitor::handleDistance() {
 }
 
 void DistanceMonitor::_getDistance() {
-  _distance = _sensor.Distance();
+  _distance = _sensor.getDistance();
 }
 
 bool DistanceMonitor::_isFar() {

--- a/uno/DistanceMonitor.h
+++ b/uno/DistanceMonitor.h
@@ -8,7 +8,7 @@
 #endif
 
 #include <inttypes.h>
-#include <SR04.h>
+#include "DistanceSensor.h"
 
 struct Range {
 	int min;
@@ -25,8 +25,13 @@ struct DistanceSetting {
 	void (*withinRangeHandler) ();
 };
 
+struct SensorSettings {
+	int inPin;
+	int outPin;
+};
+
 struct DistanceMonitorParams {
-	SR04 sensor;
+	SensorSettings sensorSettings;
 	IntervalSettings intervalSettings;
 	DistanceSetting nearSettings;
 	DistanceSetting farSettings;
@@ -38,7 +43,7 @@ class DistanceMonitor {
 		void handleDistance();
 
 	private:
-		SR04 _sensor;
+		DistanceSensor _sensor;
 		IntervalSettings _intervalSettings;
 		Range _nearRange;
 		Range _farRange;

--- a/uno/DistanceSensor.cpp
+++ b/uno/DistanceSensor.cpp
@@ -1,0 +1,7 @@
+#include "DistanceSensor.h"
+
+DistanceSensor::DistanceSensor(int inPin, int outPin) : _sensor(outPin, inPin) {}
+
+int DistanceSensor::getDistance() { 
+  return _sensor.Distance(); 
+}

--- a/uno/DistanceSensor.h
+++ b/uno/DistanceSensor.h
@@ -1,0 +1,21 @@
+#ifndef DistanceSensor_H
+#define DistanceSensor_H
+
+#if defined(ARDUINO) && ARDUINO >= 100
+	#include "Arduino.h"
+#else
+	#include "WProgram.h"
+#endif
+
+#include <inttypes.h>
+#include "SR04.h"
+
+class DistanceSensor {
+	public:
+		DistanceSensor(int inPin, int outPin);
+    int getDistance();
+
+	private:
+    SR04 _sensor;
+};
+#endif

--- a/uno/uno.ino
+++ b/uno/uno.ino
@@ -1,10 +1,8 @@
 #include "Consts.h"
 #include "Goose.h"
 #include "Relay.h"
-#include "SR04.h"
 #include "DistanceMonitor.h"
 
-SR04 sr04 = SR04(ECHO_PIN, TRIGGER_PIN);
 Relay nearRelay = Relay(NEAR_CTL_PIN);
 Relay farRelay = Relay(FAR_CTL_PIN);
 
@@ -26,7 +24,7 @@ Goose goose = Goose({
 });
 
 DistanceMonitor distanceMonitor = DistanceMonitor({
-   .sensor = sr04,
+   .sensorSettings = {ECHO_PIN, TRIGGER_PIN},
    .intervalSettings = {PING_DELAY_MS, PING_COUNT},
    .nearSettings = {
       {NEAR_MIN_CM, NEAR_MAX_CM},

--- a/uno/uno.ino
+++ b/uno/uno.ino
@@ -24,7 +24,7 @@ Goose goose = Goose({
 });
 
 DistanceMonitor distanceMonitor = DistanceMonitor({
-   .sensorSettings = {ECHO_PIN, TRIGGER_PIN},
+   .sensorSettings = {SENSOR_PIN_IN, SENSOR_PIN_OUT},
    .intervalSettings = {PING_DELAY_MS, PING_COUNT},
    .nearSettings = {
       {NEAR_MIN_CM, NEAR_MAX_CM},


### PR DESCRIPTION
**Reason for Changes**
- Decouple `DistanceMonitor` logic from a specific piece of hardware (SR04) by wrapping the SR04 instance with another class
- Proactively reduce complexity since additional sensors will be added in subsequent PR's by abstracting instantiation of sensors to occur within the `DistanceMonitor` class

**Changes**
- Add a `DistanceSensor` wrapper around the `SR04`, to decouple the `DistanceMonitor` logic from specific hardware and rename method invocations on the instantiated `DistanceSensor` object as needed
- Instantiate `DistanceSensor` within `DistanceMonitor` instead of passing the sensor object as an argument to `DistanceMonitor` 

**Minor Refactoring Changes**
- Use `const inst` instead of `#define` in `Consts.h`